### PR TITLE
setting up private config for RSV-B

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ benchmarks/
 ingest/benchmarks/
 ingest/rsv-a_nextclade/
 ingest/rsv-b_nextclade/
+private_data/
 
 # Snakemake
 .snakemake/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,27 @@ nextstrain build . --configfile profiles/wadoh/configfile_wadoh.yaml
 
 To test the pipeline with the provided example data located in ```example_data/```, you will need to copy over the contents of this folder, including the ```a/``` and ```b/``` subfolders, into the ```data/``` folder. The Snakefile will pull ingest the contents of the ```data/``` folder into the build.
 
+#### Run the Build with Private Data Spike in
+
+This will incorporate whatever private data you provide alongside the exiting ingest & sampling rules. 
+
+1. Edit line 23 of ```profiles/wadoh/private-config.yaml``` to specify the subtype(s) you have private data for (accepts any of: ```subtypes: ['A'], ['B'], or ['A', 'B']```).
+2. Add private data:
+    - ```private_data/{a_or_b}/private_metadata.tsv``` A template is provided. Metadata must include the below columns:
+        - ```accession```: The WA ID associated with the sample
+        - ```strain```: Also the WA ID - this replaces accession as the ID in the final .json
+        - ```date```: in format XXXX-XX-XX (note that this workflow exludes samples with date ambiguity by year - ie. 2026-XX-XX is ok but 202X-XXX-XXX is not)
+        - ```division```: 'Washington'
+        - ```country```: 'USA'
+        - ```qc.overallStatus```: ex. 'good'
+        - ```genome_coverage```: ex. 1
+        - ```missing_data```: 0
+    - ```private_data/{a_or_b}/private_sequences.fasta```
+3. Run with
+    ```
+    nextstrain build . --configfile profiles/wadoh/private-config.yaml
+    ```
+
 ### Repository File Structure Overview
 The file structure of the repository is as follows with `*`" folders denoting folders that are the build's expected outputs.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This will incorporate whatever private data you provide alongside the exiting in
 
 1. Edit line 23 of ```profiles/wadoh/private-config.yaml``` to specify the subtype(s) you have private data for (accepts any of: ```subtypes: ['A'], ['B'], or ['A', 'B']```).
 2. Add private data:
-    - ```private_data/{a_or_b}/private_metadata.tsv``` A template is provided. Metadata must include the below columns:
+    - ```private_data/{a_or_b}/private_metadata.tsv``` Metadata must include the below columns:
         - ```accession```: The WA ID associated with the sample
         - ```strain```: Also the WA ID - this replaces accession as the ID in the final .json
         - ```date```: in format XXXX-XX-XX (note that this workflow exludes samples with date ambiguity by year - ie. 2026-XX-XX is ok but 202X-XXX-XXX is not)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This will incorporate whatever private data you provide alongside the exiting in
     - ```private_data/{a_or_b}/private_metadata.tsv``` Metadata must include the below columns:
         - ```accession```: The WA ID associated with the sample
         - ```strain```: Also the WA ID - this replaces accession as the ID in the final .json
-        - ```date```: in format XXXX-XX-XX (note that this workflow exludes samples with date ambiguity by year - ie. 2026-XX-XX is ok but 202X-XXX-XXX is not)
+        - ```date```: in format XXXX-XX-XX (note that this workflow excludes samples with date ambiguity by year - ie. 2026-XX-XX is ok but 202X-XXX-XXX is not)
         - ```division```: 'Washington'
         - ```country```: 'USA'
         - ```qc.overallStatus```: ex. 'good'

--- a/profiles/wadoh/private-config-b.yaml
+++ b/profiles/wadoh/private-config-b.yaml
@@ -1,0 +1,94 @@
+conda_environment: "workflow/envs/nextstrain.yaml"
+
+custom_rules:
+  - "profiles/wadoh/wa_filter.smk"
+
+genesforglycosylation: ["G", "F"]
+
+builds_to_run: ["genome"]
+
+resolutions_to_run: ["6y"]
+
+# Both files must have a {a_or_b} expandable field to be replaced by "a" or "b"
+# depending on if they are specified in the `subtypes` param above
+subtypes: ['b']
+inputs:
+  - name: ppx_open
+    metadata: "https://data.nextstrain.org/files/workflows/rsv/b/metadata.tsv.gz"
+    sequences: "https://data.nextstrain.org/files/workflows/rsv/b/sequences.fasta.xz"
+  - name: ppx_restricted
+    metadata: "https://data.nextstrain.org/files/workflows/rsv/b/metadata_restricted.tsv.gz"
+    sequences: "https://data.nextstrain.org/files/workflows/rsv/b/sequences_restricted.fasta.xz"
+
+subtypes: ["b"]
+additional_inputs:
+  - name: private-data
+    metadata: private_data/b/private_metadata.tsv
+    sequences: private_data/b/private_sequences.fasta
+
+exclude: "config/outliers_ppx.txt"
+
+description: "config/description.md"
+
+strain_id_field: "accession"
+display_strain_field: "strain"
+
+
+filter:
+  group_by: "year country division"
+  min_coverage:
+    genome: 0.3
+    G: 0.3
+    F: 0.3
+
+  min_length:
+    genome: 10000
+    G: 600
+    F: 1200
+  resolutions: #If adding new resolutions, need to add to config/distance_maps.tsv
+    all-time:
+      min_date: 1975-01-01
+    6y:
+      min_date: 6Y
+      background_min_date: 12Y
+    3y:
+      min_date: 3Y
+      background_min_date: 12Y
+    1y:
+      min_date: 1Y
+      background_min_date: 12Y
+
+  subsample_max_sequences:
+    genome: 3000
+    G: 3000
+    F: 3000
+
+files:
+  auspice_config: "profiles/wadoh/auspice_config_wa.json"
+  auspice_config_additional_colorings: "config/auspice_config_additional_colorings.json"
+
+refine:
+  coalescent: "opt"
+  date_inference: "marginal"
+  clock_filter_iqd: 4
+
+ancestral:
+  inference: "joint"
+
+cds:
+  F: "F"
+  G: "G"
+  genome: "F"
+
+traits:
+  columns: "country region"
+
+nextclade_attributes:
+  a:
+    name: "RSV-A NextClade using real-time tree"
+    reference_name: "hRSV/A/England/397/2017"
+    accession: "EPI_ISL_412866"
+  b:
+    name: "RSV-B NextClade using real-time tree"
+    reference_name: "hRSV/B/Australia/VIC-RCH056/2019"
+    accession: "EPI_ISL_1653999"

--- a/profiles/wadoh/private-config-b.yaml
+++ b/profiles/wadoh/private-config-b.yaml
@@ -42,7 +42,7 @@ filter:
     F: 0.3
 
   min_length:
-    genome: 10000
+    genome: 14500
     G: 600
     F: 1200
   resolutions: #If adding new resolutions, need to add to config/distance_maps.tsv
@@ -71,6 +71,7 @@ refine:
   coalescent: "opt"
   date_inference: "marginal"
   clock_filter_iqd: 4
+  divergence_units: "mutations"
 
 ancestral:
   inference: "joint"


### PR DESCRIPTION
I set up a new config file for a private build - `profiles/wadoh/private-config-b.yaml`. The private sequences and metadata are masked by `.gitignore`.

I can do the same for RSV-A if you all would like. We don't have any private RSV-A data yet.

This can be tested with:
```
nextstrain build . --forceall --configfile profiles/wadoh/private-config-b.yaml
```
Let me know if you all would like the private data folder for testing purposes.